### PR TITLE
Prevent fragment id from being overwritten

### DIFF
--- a/flowr/src/main/java/com/fueled/flowr/AbstractFlowrFragment.java
+++ b/flowr/src/main/java/com/fueled/flowr/AbstractFlowrFragment.java
@@ -23,8 +23,10 @@ public abstract class AbstractFlowrFragment extends Fragment implements FlowrFra
         super.onActivityCreated(savedInstanceState);
 
         if (savedInstanceState != null) {
-            fragmentId = savedInstanceState.getString(KEY_FRAGMENT_ID, UUID.randomUUID().toString());
-        } else {
+            fragmentId = savedInstanceState.getString(KEY_FRAGMENT_ID, null);
+        }
+        
+        if (fragmentId == null) {
             fragmentId = UUID.randomUUID().toString();
         }
     }


### PR DESCRIPTION
# Description

Prevent `fragmentId` from being overwritten when the fragment is popped back from backstack after being replaced by another fragment.