### PR TITLE
Extend custom transition

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:2.3.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/extra/gradle/libraries.gradle
+++ b/extra/gradle/libraries.gradle
@@ -9,7 +9,7 @@ ext {
 
     //library
     libraryGroup = 'com.github.fueled'
-    libraryVersion = '1.0.1'
+    libraryVersion = '1.1.1'
 
     //android libraries
     supportVersion = '25.1.1'

--- a/flowr/src/main/java/com/fueled/flowr/Flowr.java
+++ b/flowr/src/main/java/com/fueled/flowr/Flowr.java
@@ -263,9 +263,10 @@ public class Flowr implements FragmentManager.OnBackStackChangedListener,
                                      @AnimRes int exitAnim, @AnimRes int popEnterAnim, @AnimRes int popExitAnim) {
         transaction.setCustomAnimations(
                 enterAnim,
-                popExitAnim,
+                exitAnim,
                 popEnterAnim,
-                exitAnim);
+                popExitAnim
+        );
     }
 
     private Fragment retrieveCurrentFragment() {
@@ -568,12 +569,12 @@ public class Flowr implements FragmentManager.OnBackStackChangedListener,
          * @param exitAnim  the fragment exit animation.
          */
         public Builder setCustomTransactionAnimation(@AnimRes int enterAnim, @AnimRes int exitAnim) {
-            return setCustomTransactionAnimation(enterAnim, exitAnim, FragmentTransaction.TRANSIT_NONE, FragmentTransaction.TRANSIT_NONE);
+            return setCustomTransactionAnimation(enterAnim, FragmentTransaction.TRANSIT_NONE, FragmentTransaction.TRANSIT_NONE, exitAnim);
         }
 
 
         /**
-         * Set a Custom Animation to a Fragment transaction
+         * Set a Custom Animation to a Fragment transaction.
          *
          * @param enterAnim    The animation resource to be used when the next fragment enters.
          * @param exitAnim     The animation resource to be used when the current fragment exits.

--- a/flowr/src/main/java/com/fueled/flowr/Flowr.java
+++ b/flowr/src/main/java/com/fueled/flowr/Flowr.java
@@ -26,14 +26,11 @@ public class Flowr implements FragmentManager.OnBackStackChangedListener,
     private final static String KEY_REQUEST_CODE = "KEY_REQUEST_CODE";
 
     private final static String TAG = Flowr.class.getSimpleName();
-
+    private final FragmentsResultPublisher resultPublisher;
+    private final int mainContainerId;
     private FlowrScreen screen;
     private ToolbarHandler toolbarHandler;
     private DrawerHandler drawerHandler;
-
-    private final FragmentsResultPublisher resultPublisher;
-    private final int mainContainerId;
-
     private Fragment currentFragment;
 
     private boolean overrideBack;
@@ -109,6 +106,32 @@ public class Flowr implements FragmentManager.OnBackStackChangedListener,
         setDrawerHandler(drawerHandler);
 
         syncScreenState();
+    }
+
+    /**
+     * Build and return a new ResultResponse instant using the arguments passed in.
+     *
+     * @param arguments  Used to retrieve the ID and request code for the fragment
+     *                   requesting the results.
+     * @param resultCode The results code to be returned.
+     * @param data       Used to return extra data that might be required.
+     * @return a new {@link ResultResponse} instance
+     */
+    public static ResultResponse getResultsResponse(Bundle arguments, int resultCode, Bundle data) {
+        if (arguments == null || !arguments.containsKey(KEY_REQUEST_BUNDLE)) {
+            return null;
+        }
+
+        ResultResponse resultResponse = new ResultResponse();
+        resultResponse.resultCode = resultCode;
+        resultResponse.data = data;
+
+        Bundle requestBundle = arguments.getBundle(KEY_REQUEST_BUNDLE);
+
+        resultResponse.fragmentId = requestBundle.getString(KEY_FRAGMENT_ID);
+        resultResponse.requestCode = requestBundle.getInt(KEY_REQUEST_CODE);
+
+        return resultResponse;
     }
 
     /**
@@ -208,7 +231,7 @@ public class Flowr implements FragmentManager.OnBackStackChangedListener,
                 transaction.addToBackStack(id);
             }
 
-            setCustomAnimations(transaction, data.getEnterAnim(), data.getExitAnim());
+            setCustomAnimations(transaction, data.getEnterAnim(), data.getExitAnim(), data.getPopEnterAnim(), data.getPopExitAnim());
 
             if (data.isReplaceCurrentFragment() && !data.isSkipBackStack()) {
                 transaction.replace(mainContainerId, fragment);
@@ -227,13 +250,22 @@ public class Flowr implements FragmentManager.OnBackStackChangedListener,
         }
     }
 
+    /**
+     * Set a Custom Animation to a Fragment transaction
+     *
+     * @param transaction  The transaction that will
+     * @param enterAnim    The animation resource to be used when the next fragment enters.
+     * @param exitAnim     The animation resource to be used when the current fragment exits.
+     * @param popEnterAnim The animation resource to be used when the previous fragment enters on back pressed.
+     * @param popExitAnim  The animation resource to be used when the current fragment exits on back pressed..
+     */
     private void setCustomAnimations(FragmentTransaction transaction, @AnimRes int enterAnim,
-                                     @AnimRes int exitAnim) {
+                                     @AnimRes int exitAnim, @AnimRes int popEnterAnim, @AnimRes int popExitAnim) {
         transaction.setCustomAnimations(
                 enterAnim,
-                FragmentTransaction.TRANSIT_NONE,
-                FragmentTransaction.TRANSIT_NONE,
-                exitAnim);
+                exitAnim,
+                popEnterAnim,
+                popExitAnim);
     }
 
     private Fragment retrieveCurrentFragment() {
@@ -250,15 +282,6 @@ public class Flowr implements FragmentManager.OnBackStackChangedListener,
     @Override
     public void onBackStackChanged() {
         setCurrentFragment(retrieveCurrentFragment());
-    }
-
-    private void setCurrentFragment(Fragment newFragment) {
-        if (currentFragment != newFragment) {
-            updateVisibilityState(currentFragment, false);
-            currentFragment = newFragment;
-            updateVisibilityState(currentFragment, true);
-            syncScreenState();
-        }
     }
 
     private void updateVisibilityState(Fragment fragment, boolean shown) {
@@ -372,6 +395,15 @@ public class Flowr implements FragmentManager.OnBackStackChangedListener,
         return currentFragment;
     }
 
+    private void setCurrentFragment(Fragment newFragment) {
+        if (currentFragment != newFragment) {
+            updateVisibilityState(currentFragment, false);
+            currentFragment = newFragment;
+            updateVisibilityState(currentFragment, true);
+            syncScreenState();
+        }
+    }
+
     /**
      * Called by the {@link android.app.Activity#onPostCreate(Bundle)} to update
      * the state of the container screen.
@@ -434,32 +466,6 @@ public class Flowr implements FragmentManager.OnBackStackChangedListener,
      */
     public <T extends Fragment & FlowrFragment> Builder open(Class<? extends T> fragmentClass) {
         return new Builder<>(fragmentClass);
-    }
-
-    /**
-     * Build and return a new ResultResponse instant using the arguments passed in.
-     *
-     * @param arguments  Used to retrieve the ID and request code for the fragment
-     *                   requesting the results.
-     * @param resultCode The results code to be returned.
-     * @param data       Used to return extra data that might be required.
-     * @return a new {@link ResultResponse} instance
-     */
-    public static ResultResponse getResultsResponse(Bundle arguments, int resultCode, Bundle data) {
-        if (arguments == null || !arguments.containsKey(KEY_REQUEST_BUNDLE)) {
-            return null;
-        }
-
-        ResultResponse resultResponse = new ResultResponse();
-        resultResponse.resultCode = resultCode;
-        resultResponse.data = data;
-
-        Bundle requestBundle = arguments.getBundle(KEY_REQUEST_BUNDLE);
-
-        resultResponse.fragmentId = requestBundle.getString(KEY_FRAGMENT_ID);
-        resultResponse.requestCode = requestBundle.getInt(KEY_REQUEST_CODE);
-
-        return resultResponse;
     }
 
     /**
@@ -544,9 +550,26 @@ public class Flowr implements FragmentManager.OnBackStackChangedListener,
          * @param exitAnim  the fragment exit animation.
          */
         public Builder setCustomTransactionAnimation(@AnimRes int enterAnim, @AnimRes int exitAnim) {
+            return setCustomTransactionAnimation(enterAnim, exitAnim, FragmentTransaction.TRANSIT_NONE, FragmentTransaction.TRANSIT_NONE);
+        }
+
+
+        /**
+         * Set a Custom Animation to a Fragment transaction
+         *
+         * @param enterAnim    The animation resource to be used when the next fragment enters.
+         * @param exitAnim     The animation resource to be used when the current fragment exits.
+         * @param popEnterAnim The animation resource to be used when the previous fragment enters on back pressed.
+         * @param popExitAnim  The animation resource to be used when the current fragment exits on back pressed..
+         */
+        public Builder setCustomTransactionAnimation(@AnimRes int enterAnim,
+                                                     @AnimRes int exitAnim, @AnimRes int popEnterAnim, @AnimRes int popExitAnim) {
             data.setEnterAnim(enterAnim);
             data.setExitAnim(exitAnim);
+            data.setPopEnterAnim(popEnterAnim);
+            data.setPopExitAnim(popExitAnim);
             return this;
+
         }
 
         /**

--- a/flowr/src/main/java/com/fueled/flowr/Flowr.java
+++ b/flowr/src/main/java/com/fueled/flowr/Flowr.java
@@ -486,6 +486,24 @@ public class Flowr implements FragmentManager.OnBackStackChangedListener,
         return FragmentTransaction.TRANSIT_NONE;
     }
 
+    /**
+     * The default pop enter animation to be used for fragment transactions
+     *
+     * @return the default fragment pop enter animation
+     */
+    protected int getDefaultPopEnterAnimation() {
+        return FragmentTransaction.TRANSIT_NONE;
+    }
+
+    /**
+     * The default pop exit animation to be used for fragment transactions
+     *
+     * @return the default fragment pop exit animation
+     */
+    protected int getDefaultPopExitAnimation() {
+        return FragmentTransaction.TRANSIT_NONE;
+    }
+
     @Override
     public void onClick(View view) {
         onNavigationIconClicked();

--- a/flowr/src/main/java/com/fueled/flowr/Flowr.java
+++ b/flowr/src/main/java/com/fueled/flowr/Flowr.java
@@ -263,9 +263,9 @@ public class Flowr implements FragmentManager.OnBackStackChangedListener,
                                      @AnimRes int exitAnim, @AnimRes int popEnterAnim, @AnimRes int popExitAnim) {
         transaction.setCustomAnimations(
                 enterAnim,
-                exitAnim,
+                popExitAnim,
                 popEnterAnim,
-                popExitAnim);
+                exitAnim);
     }
 
     private Fragment retrieveCurrentFragment() {

--- a/flowr/src/main/java/com/fueled/flowr/internal/TransactionData.java
+++ b/flowr/src/main/java/com/fueled/flowr/internal/TransactionData.java
@@ -2,6 +2,7 @@ package com.fueled.flowr.internal;
 
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentTransaction;
 
 import com.fueled.flowr.FlowrFragment;
 
@@ -9,7 +10,7 @@ import com.fueled.flowr.FlowrFragment;
  * Created by hussein@fueled.com on 16/02/2017.
  * Copyright (c) 2017 Fueled. All rights reserved.
  */
-public final class TransactionData<T  extends Fragment & FlowrFragment> {
+public final class TransactionData<T extends Fragment & FlowrFragment> {
 
     private Class<? extends T> fragmentClass;
     private Bundle args;
@@ -18,6 +19,8 @@ public final class TransactionData<T  extends Fragment & FlowrFragment> {
     private boolean replaceCurrentFragment = false;
     private int enterAnim;
     private int exitAnim;
+    private int popEnterAnim = FragmentTransaction.TRANSIT_NONE;
+    private int popExitAnim = FragmentTransaction.TRANSIT_NONE;
 
     public TransactionData(Class<? extends T> fragmentClass) {
         this.fragmentClass = fragmentClass;
@@ -27,6 +30,22 @@ public final class TransactionData<T  extends Fragment & FlowrFragment> {
         this.fragmentClass = fragmentClass;
         this.enterAnim = enterAnim;
         this.exitAnim = exitAnim;
+    }
+
+    public int getPopEnterAnim() {
+        return popEnterAnim;
+    }
+
+    public void setPopEnterAnim(int popEnterAnim) {
+        this.popEnterAnim = popEnterAnim;
+    }
+
+    public int getPopExitAnim() {
+        return popExitAnim;
+    }
+
+    public void setPopExitAnim(int popExitAnim) {
+        this.popExitAnim = popExitAnim;
     }
 
     public Class<? extends T> getFragmentClass() {

--- a/flowr/src/main/java/com/fueled/flowr/internal/TransactionData.java
+++ b/flowr/src/main/java/com/fueled/flowr/internal/TransactionData.java
@@ -19,17 +19,27 @@ public final class TransactionData<T extends Fragment & FlowrFragment> {
     private boolean replaceCurrentFragment = false;
     private int enterAnim;
     private int exitAnim;
-    private int popEnterAnim = FragmentTransaction.TRANSIT_NONE;
-    private int popExitAnim = FragmentTransaction.TRANSIT_NONE;
+    private int popEnterAnim;
+    private int popExitAnim;
 
     public TransactionData(Class<? extends T> fragmentClass) {
-        this.fragmentClass = fragmentClass;
+        init(fragmentClass, FragmentTransaction.TRANSIT_NONE, FragmentTransaction.TRANSIT_NONE, FragmentTransaction.TRANSIT_NONE, FragmentTransaction.TRANSIT_NONE);
     }
 
     public TransactionData(Class<? extends T> fragmentClass, int enterAnim, int exitAnim) {
+        init(fragmentClass, enterAnim, exitAnim, FragmentTransaction.TRANSIT_NONE, FragmentTransaction.TRANSIT_NONE);
+    }
+
+    public TransactionData(Class<? extends T> fragmentClass, int enterAnim, int exitAnim, int popEnterAnim, int popExitAnim) {
+        init(fragmentClass, enterAnim, exitAnim, popEnterAnim, popExitAnim);
+    }
+
+    protected void init(Class<? extends T> fragmentClass, int enterAnim, int exitAnim, int popEnterAnim, int popExitAnim) {
         this.fragmentClass = fragmentClass;
         this.enterAnim = enterAnim;
         this.exitAnim = exitAnim;
+        this.popEnterAnim = popEnterAnim;
+        this.popExitAnim = popExitAnim;
     }
 
     public int getPopEnterAnim() {

--- a/sample/src/main/java/com/fueled/flowr/sample/HomeFragment.java
+++ b/sample/src/main/java/com/fueled/flowr/sample/HomeFragment.java
@@ -4,7 +4,6 @@ import android.databinding.DataBindingUtil;
 import android.view.View;
 
 import com.fueled.flowr.NavigationIconType;
-import com.fueled.flowr.sample.R;
 import com.fueled.flowr.sample.core.AbstractFragment;
 import com.fueled.flowr.sample.databinding.FragmentHomeBinding;
 
@@ -14,36 +13,37 @@ import com.fueled.flowr.sample.databinding.FragmentHomeBinding;
  */
 public class HomeFragment extends AbstractFragment implements View.OnClickListener {
 
-	private FragmentHomeBinding binding;
+    private FragmentHomeBinding binding;
 
-	@Override
-	public int getLayoutId() {
-		return R.layout.fragment_home;
-	}
+    @Override
+    public int getLayoutId() {
+        return R.layout.fragment_home;
+    }
 
-	@Override
-	protected void setupView(View view) {
-		binding = DataBindingUtil.bind(view);
-		binding.homeOpenViewButton.setOnClickListener(this);
-	}
+    @Override
+    protected void setupView(View view) {
+        binding = DataBindingUtil.bind(view);
+        binding.homeOpenViewButton.setOnClickListener(this);
+    }
 
-	@Override
-	public boolean onNavigationIconClick() {
-		return true;
-	}
+    @Override
+    public boolean onNavigationIconClick() {
+        return true;
+    }
 
-	@Override
-	public NavigationIconType getNavigationIconType() {
-		return NavigationIconType.HIDDEN;
-	}
+    @Override
+    public NavigationIconType getNavigationIconType() {
+        return NavigationIconType.HIDDEN;
+    }
 
-	@Override
-	public void onClick(View view) {
-		displayViewFragment();
-	}
+    @Override
+    public void onClick(View view) {
+        displayViewFragment();
+    }
 
-	private void displayViewFragment() {
-		getRouter().open(ViewFragment.class)
-				.displayFragment();
-	}
+    private void displayViewFragment() {
+        getRouter().open(ViewFragment.class)
+                .setCustomTransactionAnimation(android.R.anim.fade_in, android.R.anim.fade_out, android.R.anim.slide_in_left, android.R.anim.slide_out_right)
+                .displayFragment();
+    }
 }

--- a/sample/src/main/java/com/fueled/flowr/sample/MainActivity.java
+++ b/sample/src/main/java/com/fueled/flowr/sample/MainActivity.java
@@ -5,8 +5,8 @@ import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.view.View;
 
-import com.fueled.flowr.NavigationIconType;
 import com.fueled.flowr.Flowr;
+import com.fueled.flowr.NavigationIconType;
 import com.fueled.flowr.ToolbarHandler;
 import com.fueled.flowr.sample.core.AbstractActivity;
 import com.fueled.flowr.sample.core.FragmentResultPublisherImpl;


### PR DESCRIPTION
Add the ability to specify popEnter and popExit to [setCustomTransactionAnimation](https://github.com/Fueled/flowr/blob/extend-custom-transition/flowr/src/main/java/com/fueled/flowr/Flowr.java#L565) as requested by #12.

To use it, simply call:
```java
getRouter().open(ViewFragment.class)
                .setCustomTransactionAnimation(android.R.anim.fade_in, android.R.anim.fade_out, android.R.anim.slide_in_left, android.R.anim.slide_out_right)
                .displayFragment();
```