### PR TITLE
Fix default pop exnter/exit animations ignored

### DIFF
--- a/flowr/src/main/java/com/fueled/flowr/AbstractFlowrFragment.java
+++ b/flowr/src/main/java/com/fueled/flowr/AbstractFlowrFragment.java
@@ -26,7 +26,7 @@ public abstract class AbstractFlowrFragment extends Fragment implements FlowrFra
         if (savedInstanceState != null) {
             fragmentId = savedInstanceState.getString(KEY_FRAGMENT_ID, null);
         }
-        
+
         if (fragmentId == null) {
             fragmentId = UUID.randomUUID().toString();
         }

--- a/flowr/src/main/java/com/fueled/flowr/Flowr.java
+++ b/flowr/src/main/java/com/fueled/flowr/Flowr.java
@@ -525,7 +525,8 @@ public class Flowr implements FragmentManager.OnBackStackChangedListener,
 
         public Builder(Class<? extends T> fragmentClass) {
             data = new TransactionData<>(fragmentClass, getDefaultEnterAnimation(),
-                    getDefaultExitAnimation());
+                    getDefaultExitAnimation(), getDefaultPopEnterAnimation(),
+                    getDefaultPopExitAnimation());
         }
 
         /**

--- a/flowr/src/main/java/com/fueled/flowr/internal/TransactionData.java
+++ b/flowr/src/main/java/com/fueled/flowr/internal/TransactionData.java
@@ -23,18 +23,16 @@ public final class TransactionData<T extends Fragment & FlowrFragment> {
     private int popExitAnim;
 
     public TransactionData(Class<? extends T> fragmentClass) {
-        init(fragmentClass, FragmentTransaction.TRANSIT_NONE, FragmentTransaction.TRANSIT_NONE, FragmentTransaction.TRANSIT_NONE, FragmentTransaction.TRANSIT_NONE);
+        this(fragmentClass, FragmentTransaction.TRANSIT_NONE, FragmentTransaction.TRANSIT_NONE);
     }
 
     public TransactionData(Class<? extends T> fragmentClass, int enterAnim, int exitAnim) {
-        init(fragmentClass, enterAnim, exitAnim, FragmentTransaction.TRANSIT_NONE, FragmentTransaction.TRANSIT_NONE);
+        this(fragmentClass, enterAnim, exitAnim, FragmentTransaction.TRANSIT_NONE,
+                FragmentTransaction.TRANSIT_NONE);
     }
 
-    public TransactionData(Class<? extends T> fragmentClass, int enterAnim, int exitAnim, int popEnterAnim, int popExitAnim) {
-        init(fragmentClass, enterAnim, exitAnim, popEnterAnim, popExitAnim);
-    }
-
-    protected void init(Class<? extends T> fragmentClass, int enterAnim, int exitAnim, int popEnterAnim, int popExitAnim) {
+    public TransactionData(Class<? extends T> fragmentClass, int enterAnim, int exitAnim,
+                           int popEnterAnim, int popExitAnim) {
         this.fragmentClass = fragmentClass;
         this.enterAnim = enterAnim;
         this.exitAnim = exitAnim;

--- a/sample/src/main/java/com/fueled/flowr/sample/ViewFragment.java
+++ b/sample/src/main/java/com/fueled/flowr/sample/ViewFragment.java
@@ -5,7 +5,6 @@ import android.view.View;
 
 import com.fueled.flowr.sample.core.AbstractFragment;
 import com.fueled.flowr.sample.databinding.FragmentViewBinding;
-import com.fueled.flowr.sample.R;
 
 /**
  * Created by hussein@fueled.com on 14/02/2017.


### PR DESCRIPTION
# Description

* Fixes issue with values from `Flowr#getDefaultPopEnterAnimation()` and `Flowr#getDefaultPopExitAnimation()` being ignored.