### PR TITLE
Refactor clear back stack call

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,9 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com'
+        }
     }
 }
 

--- a/extra/gradle/libraries.gradle
+++ b/extra/gradle/libraries.gradle
@@ -1,10 +1,10 @@
 ext {
 
     //app
-    compileSdk = 25
+    compileSdk = 26
     buildTools = "25.0.2"
     minSdk = 16
-    targetSdk = 25
+    targetSdk = 26
     appId = "com.fueled.flowr.sample"
 
     //library
@@ -12,7 +12,7 @@ ext {
     libraryVersion = '1.4.0'
 
     //android libraries
-    supportVersion = '25.1.1'
+    supportVersion = '26.1.0'
 
     // Rx
     rxJavaVersion = '2.0.4'

--- a/extra/gradle/libraries.gradle
+++ b/extra/gradle/libraries.gradle
@@ -2,7 +2,7 @@ ext {
 
     //app
     compileSdk = 26
-    buildTools = "25.0.2"
+    buildTools = "26.0.1"
     minSdk = 16
     targetSdk = 26
     appId = "com.fueled.flowr.sample"

--- a/flowr/build.gradle
+++ b/flowr/build.gradle
@@ -34,3 +34,27 @@ dependencies {
     testCompile testLibraries.junit
     testCompile testLibraries.mockito
 }
+
+// build a jar with source files
+task sourcesJar(type: Jar) {
+    from android.sourceSets.main.java.srcDirs
+    classifier = 'sources'
+}
+
+task javadoc(type: Javadoc) {
+    failOnError  false
+    source = android.sourceSets.main.java.sourceFiles
+    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    classpath += configurations.compile
+}
+
+// build a jar with javadoc
+task javadocJar(type: Jar, dependsOn: javadoc) {
+    classifier = 'javadoc'
+    from javadoc.destinationDir
+}
+
+artifacts {
+    archives sourcesJar
+    archives javadocJar
+}

--- a/flowr/src/main/java/com/fueled/flowr/Flowr.java
+++ b/flowr/src/main/java/com/fueled/flowr/Flowr.java
@@ -262,18 +262,12 @@ public class Flowr implements FragmentManager.OnBackStackChangedListener,
                 clearBackStack();
             }
 
-            FragmentTransaction transaction = screen.getScreenFragmentManager().beginTransaction();
-
             currentFragment = retrieveCurrentFragment();
-
-            if (data.isReplaceCurrentFragment() && data.isSkipBackStack() && currentFragment != null) {
-                transaction.remove(currentFragment).commit();
-            }
 
             Fragment fragment = data.getFragmentClass().newInstance();
             fragment.setArguments(data.getArgs());
 
-            transaction = screen.getScreenFragmentManager().beginTransaction();
+            FragmentTransaction transaction = screen.getScreenFragmentManager().beginTransaction();
 
             if (!data.isSkipBackStack()) {
                 String id = tagPrefix + screen.getScreenFragmentManager().getBackStackEntryCount();
@@ -282,7 +276,7 @@ public class Flowr implements FragmentManager.OnBackStackChangedListener,
 
             setCustomAnimations(transaction, data.getEnterAnim(), data.getExitAnim(), data.getPopEnterAnim(), data.getPopExitAnim());
 
-            if (data.isReplaceCurrentFragment() && !data.isSkipBackStack()) {
+            if (data.isReplaceCurrentFragment()) {
                 transaction.replace(mainContainerId, fragment);
             } else {
                 transaction.add(mainContainerId, fragment);

--- a/flowr/src/main/java/com/fueled/flowr/Flowr.java
+++ b/flowr/src/main/java/com/fueled/flowr/Flowr.java
@@ -439,7 +439,7 @@ public class Flowr implements FragmentManager.OnBackStackChangedListener,
     public void clearBackStack() {
         if (screen != null) {
             screen.getScreenFragmentManager()
-                    .popBackStackImmediate(tagPrefix + "0", FragmentManager.POP_BACK_STACK_INCLUSIVE);
+                    .popBackStack(tagPrefix + "0", FragmentManager.POP_BACK_STACK_INCLUSIVE);
             currentFragment = null;
         }
     }


### PR DESCRIPTION
# Description

* Replace [`FragmentManager#popBackStackImmediate`](https://developer.android.com/reference/android/support/v4/app/FragmentManager.html#popBackStackImmediate(java.lang.String,%20int)) with [`FragmentManager#popBackStack`](https://developer.android.com/reference/android/support/v4/app/FragmentManager.html#popBackStack(java.lang.String,%20int)) for the `Flowr#clearBackStack()` call. This improves performance when combing the clear back stack call with other transactions, as it remove the need to wait for the clear stack transaction to be executed before queuing the other transactions.
* Remove the no longer needed fragment replace issue workaround, as it was fixed in support library version [`25.1.0`](https://developer.android.com/topic/libraries/support-library/revisions.html#25-1-0).
* Start generating sources and java docs artifacts when building the library.
* Update support library to version `26.1.0` and build tools to version `16.0.1`.