### PR TITLE
Fix backstack not getting cleared correctly

### DIFF
--- a/extra/gradle/libraries.gradle
+++ b/extra/gradle/libraries.gradle
@@ -1,10 +1,10 @@
 ext {
 
     //app
-    compileSdk = 26
-    buildTools = "26.0.1"
+    compileSdk = 27
+    buildTools = "27.0.3"
     minSdk = 16
-    targetSdk = 26
+    targetSdk = 27
     appId = "com.fueled.flowr.sample"
 
     //library
@@ -12,7 +12,7 @@ ext {
     libraryVersion = '1.5.1'
 
     //android libraries
-    supportVersion = '26.1.0'
+    supportVersion = '27.1.1'
 
     // Rx
     rxJavaVersion = '2.0.4'

--- a/flowr/src/main/java/com/fueled/flowr/Flowr.java
+++ b/flowr/src/main/java/com/fueled/flowr/Flowr.java
@@ -474,7 +474,7 @@ public class Flowr implements FragmentManager.OnBackStackChangedListener,
     public void clearBackStack() {
         if (screen != null) {
             screen.getScreenFragmentManager()
-                    .popBackStack(tagPrefix + "0", FragmentManager.POP_BACK_STACK_INCLUSIVE);
+                    .popBackStack(null, FragmentManager.POP_BACK_STACK_INCLUSIVE);
             currentFragment = null;
         }
     }


### PR DESCRIPTION
# Description

Start passing `null` as the fragment id when clearing the backstack to insure the backstack is correctly cleared even if the first fragment id is not `0`